### PR TITLE
Change base namespace to CrEOF\Geo\WKB to avoid class collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 ### Changed
 
+## [2.0.0] 2015-11-18
+### Added
+- Change base namespace to CrEOF\Geo\WKB to avoid class collision with other CrEOF packages.
+
 ## [1.0.1] 2015-11-17
 ### Changed
 - Replaced if/else statement with ternary operator in parseInput method of Reader.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-0": {
-            "CrEOF\\WKB": "lib/"
+            "CrEOF\\Geo\\WKB": "lib/"
         }
     }
 }

--- a/lib/CrEOF/Geo/WKB/Exception/ExceptionInterface.php
+++ b/lib/CrEOF/Geo/WKB/Exception/ExceptionInterface.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Exception;
+namespace CrEOF\Geo\WKB\Exception;
 
 /**
- * RangeException
+ * Exception interface for library exceptions
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class RangeException extends \RangeException implements ExceptionInterface
+interface ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKB/Exception/InvalidArgumentException.php
+++ b/lib/CrEOF/Geo/WKB/Exception/InvalidArgumentException.php
@@ -21,7 +21,7 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Exception;
+namespace CrEOF\Geo\WKB\Exception;
 
 /**
  * InvalidArgumentException

--- a/lib/CrEOF/Geo/WKB/Exception/RangeException.php
+++ b/lib/CrEOF/Geo/WKB/Exception/RangeException.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Exception;
+namespace CrEOF\Geo\WKB\Exception;
 
 /**
- * UnexpectedValueException
+ * RangeException
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+class RangeException extends \RangeException implements ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKB/Exception/UnexpectedValueException.php
+++ b/lib/CrEOF/Geo/WKB/Exception/UnexpectedValueException.php
@@ -21,15 +21,15 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Exception;
+namespace CrEOF\Geo\WKB\Exception;
 
 /**
- * Exception interface for library exceptions
+ * UnexpectedValueException
  *
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-interface ExceptionInterface
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
 {
 
 }

--- a/lib/CrEOF/Geo/WKB/Parser.php
+++ b/lib/CrEOF/Geo/WKB/Parser.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB;
+namespace CrEOF\Geo\WKB;
 
-use CrEOF\WKB\Exception\UnexpectedValueException;
+use CrEOF\Geo\WKB\Exception\UnexpectedValueException;
 
 /**
  * Parser for WKB/EWKB spatial object data

--- a/lib/CrEOF/Geo/WKB/Reader.php
+++ b/lib/CrEOF/Geo/WKB/Reader.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB;
+namespace CrEOF\Geo\WKB;
 
-use CrEOF\WKB\Exception\UnexpectedValueException;
+use CrEOF\Geo\WKB\Exception\UnexpectedValueException;
 
 /**
  * Reader for spatial WKB values

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
 
     <testsuites>
         <testsuite>
-            <directory>./tests/CrEOF/WKB/Tests</directory>
+            <directory>./tests/CrEOF/Geo/WKB/Tests</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/CrEOF/Geo/WKB/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKB/Tests/ParserTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Tests;
+namespace CrEOF\Geo\WKB\Tests;
 
-use CrEOF\WKB\Parser;
+use CrEOF\Geo\WKB\Parser;
 
 /**
  * Parser tests
@@ -34,7 +34,7 @@ use CrEOF\WKB\Parser;
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException        \CrEOF\WKB\Exception\UnexpectedValueException
+     * @expectedException        \CrEOF\Geo\WKB\Exception\UnexpectedValueException
      * @expectedExceptionMessage Invalid byte order "3"
      */
     public function testParsingBadByteOrder()
@@ -47,7 +47,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKB\Exception\UnexpectedValueException
+     * @expectedException        \CrEOF\Geo\WKB\Exception\UnexpectedValueException
      * @expectedExceptionMessage Unsupported WKB type "21"
      */
     public function testParsingBadType()

--- a/tests/CrEOF/Geo/WKB/Tests/ReaderTest.php
+++ b/tests/CrEOF/Geo/WKB/Tests/ReaderTest.php
@@ -21,9 +21,9 @@
  * SOFTWARE.
  */
 
-namespace CrEOF\WKB\Tests;
+namespace CrEOF\Geo\WKB\Tests;
 
-use CrEOF\WKB\Reader;
+use CrEOF\Geo\WKB\Reader;
 
 /**
  * Reader tests
@@ -62,7 +62,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKB\Exception\UnexpectedValueException
+     * @expectedException        \CrEOF\Geo\WKB\Exception\UnexpectedValueException
      * @expectedExceptionMessage Invalid byte order "unset"
      */
     public function testReadingBinaryWithoutByteOrder()
@@ -75,7 +75,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \CrEOF\WKB\Exception\UnexpectedValueException
+     * @expectedException        \CrEOF\Geo\WKB\Exception\UnexpectedValueException
      * @expectedExceptionMessage Invalid byte order "unset"
      */
     public function testReadingHexWithoutByteOrder()

--- a/tests/TestInit.php
+++ b/tests/TestInit.php
@@ -5,5 +5,5 @@ require __DIR__ . '/../vendor/autoload.php';
 error_reporting(E_ALL | E_STRICT);
 
 $loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CrEOF\WKB\Tests', __DIR__);
+$loader->add('CrEOF\Geo\WKB\Tests', __DIR__);
 $loader->register();


### PR DESCRIPTION
Change base namespace to CrEOF\Geo\WKB to avoid class collision with other CrEOF packages.
