### PR TITLE
Check machine byte order for doubles

### DIFF
--- a/lib/CrEOF/Geo/WKB/Reader.php
+++ b/lib/CrEOF/Geo/WKB/Reader.php
@@ -47,6 +47,11 @@ class Reader
     private $input;
 
     /**
+     * @var int
+     */
+    private static $machineByteOrder;
+
+    /**
      * @param string $input
      */
     public function __construct($input = null)
@@ -170,9 +175,16 @@ class Reader
     /**
      * @return bool
      */
-    private function getMachineByteOrder() {
+    private function getMachineByteOrder()
+    {
+        if (null !== self::$machineByteOrder) {
+            return self::$machineByteOrder;
+        }
+
         $result = unpack('S', "\x01\x00");
 
-        return $result[1] === 1 ? self::WKB_NDR : self::WKB_XDR;
+        self::$machineByteOrder = $result[1] === 1 ? self::WKB_NDR : self::WKB_XDR;
+
+        return self::$machineByteOrder;
     }
 }

--- a/lib/CrEOF/Geo/WKB/Reader.php
+++ b/lib/CrEOF/Geo/WKB/Reader.php
@@ -99,7 +99,7 @@ class Reader
     {
         $double = $this->unpackInput('d');
 
-        if (self::WKB_NDR === $this->getByteOrder()) {
+        if ($this->getMachineByteOrder() === $this->getByteOrder()) {
             return $double;
         }
 
@@ -165,5 +165,14 @@ class Reader
         $this->input = $result['input'];
 
         return $result['result'];
+    }
+
+    /**
+     * @return bool
+     */
+    private function getMachineByteOrder() {
+        $result = unpack('S', "\x01\x00");
+
+        return $result[1] === 1 ? self::WKB_NDR : self::WKB_XDR;
     }
 }


### PR DESCRIPTION
There are no endian specific pack/unpack format codes for doubles. Machine byte order is now checked and saved for use when unpacking doubles. All tests now pass on big endian platform. Not sure how to test this with Travis. This resolves #8.
