### PR TITLE
Add support for empty objects, rename double to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - NaN coordinates are not returned in point value array, empty point value now array().
+- Reader::readDouble() now deprecated and calls Reader::readFloat().
+- Reader::readDoubles() now deprecated and calls Reader::readFloats().
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Tests for empty geometry objects.
+
 ### Changed
+- NaN coordinates are not returned in point value array, empty point value now array().
+
+### Removed
 
 ## [2.2.0] - 2016-05-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $value2 = $parser->parse($input2);
 
 The parser will return an array with the keys ```type```, ```value```, ```srid```, and ```dimension```.
 - ```type``` string, the spatial object type (POINT, LINESTRING, etc.) without any dimension.
-- ```value``` array, contains integer or float values for points, or nested arrays containing these based on spatial object type.
+- ```value``` array, contains integer or float values for points, nested arrays containing these based on spatial object type, or empty array for EMPTY geometry.
 - ```srid``` integer, the SRID if EWKT value was parsed, ```null``` otherwise.
 - ```dimension``` string, will contain ```Z```, ```M```, or ```ZM``` for the respective 3D and 4D objects, ```null``` otherwise.
 

--- a/lib/CrEOF/Geo/WKB/Parser.php
+++ b/lib/CrEOF/Geo/WKB/Parser.php
@@ -335,7 +335,7 @@ class Parser
      */
     private function point()
     {
-        return $this->reader->readDoubles($this->pointSize);
+        return $this->reader->readFloats($this->pointSize);
     }
 
     /**

--- a/lib/CrEOF/Geo/WKB/Reader.php
+++ b/lib/CrEOF/Geo/WKB/Reader.php
@@ -124,7 +124,11 @@ class Reader
         $doubles = array();
 
         for ($i = 0; $i < $count; $i++) {
-            $doubles[] = $this->readDouble();
+            $double = $this->readDouble();
+
+            if (! is_nan($double)) {
+                $doubles[] = $double;
+            }
         }
 
         return $doubles;

--- a/lib/CrEOF/Geo/WKB/Reader.php
+++ b/lib/CrEOF/Geo/WKB/Reader.php
@@ -99,8 +99,19 @@ class Reader
     /**
      * @return float
      * @throws UnexpectedValueException
+     *
+     * @deprecated use readFloat()
      */
     public function readDouble()
+    {
+        return $this->readFloat();
+    }
+
+    /**
+     * @return float
+     * @throws UnexpectedValueException
+     */
+    public function readFloat()
     {
         $double = $this->unpackInput('d');
 
@@ -118,20 +129,33 @@ class Reader
      *
      * @return float[]
      * @throws UnexpectedValueException
+     *
+     * @deprecated use readFloats()
      */
     public function readDoubles($count)
     {
-        $doubles = array();
+        return $this->readFloats($count);
+    }
+
+    /**
+     * @param int $count
+     *
+     * @return float[]
+     * @throws UnexpectedValueException
+     */
+    public function readFloats($count)
+    {
+        $floats = array();
 
         for ($i = 0; $i < $count; $i++) {
-            $double = $this->readDouble();
+            $float = $this->readFloat();
 
-            if (! is_nan($double)) {
-                $doubles[] = $double;
+            if (! is_nan($float)) {
+                $floats[] = $float;
             }
         }
 
-        return $doubles;
+        return $floats;
     }
 
     /**

--- a/tests/CrEOF/Geo/WKB/Tests/ParserTest.php
+++ b/tests/CrEOF/Geo/WKB/Tests/ParserTest.php
@@ -80,11 +80,47 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @param       $value
+     * @param array $expected
+     *
+     * @dataProvider goodBinaryData
+     */
+    public function testParser($value, array $expected)
+    {
+        $value  = pack('H*', $value);
+        $parser = new Parser($value);
+        $actual = $parser->parse();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testReusedParser()
+    {
+        $parser = new Parser();
+
+        foreach ($this->goodBinaryData() as $testData) {
+            $value  = pack('H*', $testData['value']);
+            $actual = $parser->parse($value);
+
+            $this->assertEquals($testData['expected'], $actual);
+        }
+    }
+
+    /**
      * @return array
      */
     public function goodBinaryData()
     {
         return array(
+            'testParsingNDREmptyPointValue' => array(
+                'value' => '0101000000000000000000F87F000000000000F87F',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'POINT',
+                    'value' => array(),
+                    'dimension' => null
+                )
+            ),
             'testParsingNDRPointValue' => array(
                 'value' => '01010000003D0AD7A3701D41400000000000C055C0',
                 'expected' => array(
@@ -97,10 +133,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingXDRPointValue' => array(
                 'value' => '000000000140411D70A3D70A3DC055C00000000000',
                 'expected' => array(
-                        'srid'  => null,
-                        'type'  => 'POINT',
-                        'value' => array(34.23, -87),
-                        'dimension' => null
+                    'srid'  => null,
+                    'type'  => 'POINT',
+                    'value' => array(34.23, -87),
+                    'dimension' => null
                 )
             ),
             'testParsingNDRPointZValue' => array(
@@ -139,6 +175,24 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'dimension' => 'M'
                 )
             ),
+            'testParsingNDREmptyPointZMValue' => array(
+                'value' => '01010000C0000000000000F87F000000000000F87F000000000000F87F000000000000F87F',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'POINT',
+                    'value' => array(),
+                    'dimension' => 'ZM'
+                )
+            ),
+            'testParsingXDREmptyPointZMValue' => array(
+                'value' => '00C00000017FF80000000000007FF80000000000007FF80000000000007FF8000000000000',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'POINT',
+                    'value' => array(),
+                    'dimension' => 'ZM'
+                )
+            ),
             'testParsingNDRPointZMValue' => array(
                 'value' => '01010000C0000000000000F03F000000000000004000000000000008400000000000001040',
                 'expected' => array(
@@ -160,10 +214,10 @@ class ParserTest extends \PHPUnit_Framework_TestCase
             'testParsingNDRPointValueWithSrid' => array(
                 'value' => '01010000003D0AD7A3701D41400000000000C055C0',
                 'expected' => array(
-                        'srid'  => null,
-                        'type'  => 'POINT',
-                        'value' => array(34.23, -87),
-                        'dimension' => null
+                    'srid'  => null,
+                    'type'  => 'POINT',
+                    'value' => array(34.23, -87),
+                    'dimension' => null
                 )
             ),
             'testParsingXDRPointValueWithSrid' => array(
@@ -211,6 +265,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'dimension' => 'M'
                 )
             ),
+            'testParsingNDREmptyPointZMValueWithSrid' => array(
+                'value' => '01010000E08C100000000000000000F87F000000000000F87F000000000000F87F000000000000F87F',
+                'expected' => array(
+                    'srid'  => 4236,
+                    'type'  => 'POINT',
+                    'value' => array(),
+                    'dimension' => 'ZM'
+                )
+            ),
             'testParsingNDRPointZMValueWithSrid' => array(
                 'value' => '01010000e0e6100000000000000000f03f000000000000004000000000000008400000000000001040',
                 'expected' => array(
@@ -227,6 +290,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                     'type'  => 'POINT',
                     'value' => array(1, 2, 3, 4),
                     'dimension' => 'ZM'
+                )
+            ),
+            'testParsingNDREmptyLineStringValue' => array(
+                'value' => '010200000000000000',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'LINESTRING',
+                    'value' => array(),
+                    'dimension' => null
                 )
             ),
             'testParsingNDRLineStringValue' => array(
@@ -431,6 +503,15 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         array(1, 1, 4, 5)
                     ),
                     'dimension' => 'ZM'
+                )
+            ),
+            'testParsingNDREmptyPolygonValue' => array(
+                'value' => '010300000000000000',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'POLYGON',
+                    'value' => array(),
+                    'dimension' => null
                 )
             ),
             'testParsingNDRPolygonValue' => array(
@@ -2071,6 +2152,29 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                         )
                     ),
                     'dimension' => 'ZM'
+                )
+            ),
+            'testParsingNDREmptyGeometryCollectionValue' => array(
+                'value' => '010700000000000000',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'GEOMETRYCOLLECTION',
+                    'value' => array(),
+                    'dimension' => null
+                )
+            ),
+            'testParsingNDRGeometryCollectionValueWithEmptyPoint' => array(
+                'value' => '0107000000010000000101000000000000000000F87F000000000000F87F',
+                'expected' => array(
+                    'srid'  => null,
+                    'type'  => 'GEOMETRYCOLLECTION',
+                    'value' => array(
+                        array(
+                            'type'  => 'POINT',
+                            'value' => array()
+                        ),
+                    ),
+                    'dimension' => null
                 )
             ),
             'testParsingNDRGeometryCollectionValue' => array(
@@ -4156,34 +4260,5 @@ class ParserTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-    }
-
-    /**
-     * @param       $value
-     * @param array $expected
-     *
-     * @dataProvider goodBinaryData
-     */
-    public function testParser($value, array $expected)
-    {
-        $value  = pack('H*', $value);
-        $parser = new Parser($value);
-        $actual = $parser->parse();
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
-     */
-    public function testReusedParser()
-    {
-        $parser = new Parser();
-
-        foreach ($this->goodBinaryData() as $testData) {
-            $value  = pack('H*', $testData['value']);
-            $actual = $parser->parse($value);
-
-            $this->assertEquals($testData['expected'], $actual);
-        }
     }
 }

--- a/tests/CrEOF/Geo/WKB/Tests/ReaderTest.php
+++ b/tests/CrEOF/Geo/WKB/Tests/ReaderTest.php
@@ -136,7 +136,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $result);
     }
 
-    public function testReadingNDRBinaryDouble()
+    public function testReadingNDRBinaryFloat()
     {
         $value  = '013D0AD7A3701D4140';
         $value  = pack('H*', $value);
@@ -144,12 +144,12 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
         $reader->readByteOrder();
 
-        $result = $reader->readDouble();
+        $result = $reader->readFloat();
 
         $this->assertEquals(34.23, $result);
     }
 
-    public function testReadingXDRBinaryDouble()
+    public function testReadingXDRBinaryFloat()
     {
         $value  = '0040411D70A3D70A3D';
         $value  = pack('H*', $value);
@@ -157,31 +157,31 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
         $reader->readByteOrder();
 
-        $result = $reader->readDouble();
+        $result = $reader->readFloat();
 
         $this->assertEquals(34.23, $result);
     }
 
-    public function testReadingNDRHexDouble()
+    public function testReadingNDRHexFloat()
     {
         $value  = '013D0AD7A3701D4140';
         $reader = new Reader($value);
 
         $reader->readByteOrder();
 
-        $result = $reader->readDouble();
+        $result = $reader->readFloat();
 
         $this->assertEquals(34.23, $result);
     }
 
-    public function testReadingXDRHexDouble()
+    public function testReadingXDRHexFloat()
     {
         $value  = '0040411D70A3D70A3D';
         $reader = new Reader($value);
 
         $reader->readByteOrder();
 
-        $result = $reader->readDouble();
+        $result = $reader->readFloat();
 
         $this->assertEquals(34.23, $result);
     }
@@ -222,7 +222,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
 
         $reader->readByteOrder();
 
-        $result = $reader->readDouble();
+        $result = $reader->readFloat();
 
         $this->assertEquals(34.23, $result);
     }


### PR DESCRIPTION
- Add support for empty objects. In WKB point coordinate values are NaN, other objects have count 0. `value` index in returned array contains empty `array()`.
- Rename `Reader` methods containing the word double to float. Add deprecated stub methods to call new method names.
