### PR TITLE
Assign point size without deprecation notice

### DIFF
--- a/lib/CrEOF/Geo/WKB/Parser.php
+++ b/lib/CrEOF/Geo/WKB/Parser.php
@@ -154,7 +154,9 @@ class Parser
             }
 
             $this->dimensions = $this->getDimensions($this->type);
-            $this->pointSize  = 2 + strlen($this->getDimensionType($this->dimensions));
+            $dimensionType = this->getDimensionType($this->dimensions);
+            if($dimensionType === null) $dimensionType = '';
+            $this->pointSize  = 2 + strlen($dimensionType);
 
             $typeName = $this->getTypeName($this->type);
 


### PR DESCRIPTION
`strlen` with a `null` argument triggers a deprecation notice from PHP 8.1; this change ensures that doesn't happen anymore.