### PR TITLE
Add php 8.1 support

### DIFF
--- a/lib/CrEOF/Geo/WKB/Parser.php
+++ b/lib/CrEOF/Geo/WKB/Parser.php
@@ -154,7 +154,7 @@ class Parser
             }
 
             $this->dimensions = $this->getDimensions($this->type);
-            $this->pointSize  = 2 + strlen($this->getDimensionType($this->dimensions));
+            $this->pointSize  = 2 + strlen($this->getDimensionType($this->dimensions) || '');
 
             $typeName = $this->getTypeName($this->type);
 


### PR DESCRIPTION
As of php 8.1, the strlen() function no longer accepts null as input. This little fix bypasses the problem. No breaking changes.

@sadortun 